### PR TITLE
chore: add temporary declaration file

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,1 @@
+declare module '@egjs/agent';

--- a/package.json
+++ b/package.json
@@ -75,5 +75,6 @@
 		"webpack-merge": "^4.1.0",
 		"eslint-plugin-import": "^2.7.0",
 		"write-file-webpack-plugin": "^4.1.0"
-	}
+	},
+	"types": "index.d.ts"
 }


### PR DESCRIPTION
When trying to compile typescript project that strict mode set `true`, it cause type error because of absence of declaration file.