### PR TITLE
fix: export types related with agent

### DIFF
--- a/src/agent.ts
+++ b/src/agent.ts
@@ -69,3 +69,5 @@ function agent(userAgent?: string): AgentInfo {
 export { getLegacyAgent };
 
 export default agent;
+
+export * from "./types";


### PR DESCRIPTION
## Details
It seems that some type export was missing.
This newly exports the types used by the agent such as `AgentInfo`.
