### PR TITLE
chore: fix url of repository

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,12 +35,12 @@
 	"license": "MIT",
 	"repository": {
 		"type": "git",
-		"url": "git+https://github.com/naver/agent.git"
+		"url": "git+https://github.com/naver/egjs-agent.git"
 	},
 	"bugs": {
-		"url": "https://github.com/naver/agent/issues"
+		"url": "https://github.com/naver/egjs-agent/issues"
 	},
-	"homepage": "https://github.com/naver/agent#readme",
+	"homepage": "https://github.com/naver/egjs-agent#readme",
 	"devDependencies": {
 		"@daybrush/jsdoc": "^0.3.7",
 		"@egjs/build-helper": "^0.1.2",


### PR DESCRIPTION
## Details
<!-- Detailed description of the change/feature -->
<img width="1222" alt="image" src="https://user-images.githubusercontent.com/41318449/218939267-e2b951a6-b6af-44e5-aa0c-a1c51f4ccd97.png">


https://www.npmjs.com/package/@egjs/agent
npm 패키지 정보 우측의 repositry url과 homepage url이 깨지고 있어서 수정을 진행했습니다.