### PR TITLE
feat: enhance mobile user agent detection accuracy

### DIFF
--- a/src/userAgent.ts
+++ b/src/userAgent.ts
@@ -1,5 +1,5 @@
 import { AgentInfo } from "./types";
-import { getUserAgentString, findPreset } from "./utils";
+import { getUserAgentString, findPreset, checkIfMobile } from "./utils";
 import { WEBVIEW_PRESETS, CHROMIUM_PRESETS, BROWSER_PRESETS, OS_PRESETS, WEBKIT_PRESETS } from "./presets";
 
 export function isWebView(userAgent: string): boolean {
@@ -8,7 +8,7 @@ export function isWebView(userAgent: string): boolean {
 
 export function getLegacyAgent(userAgent?: string): AgentInfo {
     const nextAgent = getUserAgentString(userAgent);
-    const isMobile = !!/mobi/g.exec(nextAgent);
+    const isMobile = checkIfMobile(nextAgent);
     const browser = {
         name: "unknown",
         version: "-1",

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -108,3 +108,6 @@ export function findBrand(brands: NavigatorUABrandVersion[], preset: PresetInfo)
         return execRegExp(`${preset.test}`, brand.toLowerCase());
     });
 }
+export function checkIfMobile(userAgent: string): boolean {
+    return /Mobile|iP(hone|od|ad)|Android|BlackBerry|IEMobile|Kindle|NetFront|Silk-Accelerated|(hpw|web)OS|Fennec|Minimo|Opera M(obi|ini)|Blazer|Dolfin|Dolphin|Skyfire|Zune/.test(userAgent);
+}


### PR DESCRIPTION
## Details
I’ve implemented enhancements to the user agent detection to improve accuracy, addressing instances where specific user agents, such as Mozilla/5.0 (iPhone; CPU iPhone OS 17_5_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) nApps(iOS 17.5.1; iPhone; NaverBlog; 6.25.1) NAVER(inapp; blog; 100; 6.25.1), were not being detected correctly. 

The existing code used was:
```javascript
const isMobile = !!/mobi/g.exec(nextAgent);
```
To ensure comprehensive coverage of mobile user agents, I referenced a more robust regular expression from [this source](https://gist.github.com/dalethedeveloper/1503252/931cc8b613aaa930ef92a4027916e6687d07feac).

## Test Cases

Test cases were conducted to validate the accuracy of the updated detection logic:
```
1. User Agent ‘Mozilla/5.0 (iPhone; CPU iPhone OS 15_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/15E148’ => Is Mobile Device? true
2. User Agent ‘Mozilla/5.0 (Linux; Android 11; SM-G975F) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/92.0.4515.115 Mobile Safari/537.36’ => Is Mobile Device? true
3. User Agent ‘Mozilla/5.0 (Linux; U; en-us; KFOT Build/IML74K) AppleWebKit/535.19 (KHTML, like Gecko) Silk/2.2 Mobile Safari/535.19 Silk-Accelerated=true’ => Is Mobile Device? true
4. User Agent ‘Mozilla/5.0 (BB10; Touch) AppleWebKit/537.10+ (KHTML, like Gecko) Version/10.0.9.2372 Mobile Safari/537.10+’ => Is Mobile Device? true
5. User Agent ‘Mozilla/5.0 (Windows Phone 10.0; Android 4.2.1; Microsoft; Lumia 640 LTE) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/52.0.2743.116 Mobile Safari/537.36 Edge/15.15254’ => Is Mobile Device? true
6. User Agent ‘Mozilla/5.0 (iPhone; CPU iPhone OS 17_5_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) nApps(iOS 17.5.1; iPhone; NaverBlog; 6.25.1) NAVER(inapp; blog; 100; 6.25.1)’ => Is Mobile Device? true
7. User Agent ‘Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/92.0.4515.115 Safari/537.36’ => Is Mobile Device? false
8. User Agent ‘Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/92.0.4515.115 Safari/537.36’ => Is Mobile Device? false
9. User Agent ‘Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/92.0.4515.115 Safari/537.36’ => Is Mobile Device? false
```

## Test Code

``` javascript
// 테스트에 사용할 User Agent 배열
const testCases = [
  // 모바일 장치로 인식되어야 하는 경우
  "Mozilla/5.0 (iPhone; CPU iPhone OS 15_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/15E148",
  "Mozilla/5.0 (Linux; Android 11; SM-G975F) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/92.0.4515.115 Mobile Safari/537.36",
  "Mozilla/5.0 (Linux; U; en-us; KFOT Build/IML74K) AppleWebKit/535.19 (KHTML, like Gecko) Silk/2.2 Mobile Safari/535.19 Silk-Accelerated=true",
  "Mozilla/5.0 (BB10; Touch) AppleWebKit/537.10+ (KHTML, like Gecko) Version/10.0.9.2372 Mobile Safari/537.10+",
  "Mozilla/5.0 (Windows Phone 10.0; Android 4.2.1; Microsoft; Lumia 640 LTE) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/52.0.2743.116 Mobile Safari/537.36 Edge/15.15254",
  "Mozilla/5.0 (iPhone; CPU iPhone OS 17_5_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) nApps(iOS 17.5.1; iPhone; NaverBlog; 6.25.1) NAVER(inapp; blog; 100; 6.25.1)",
  
  // 모바일 장치로 인식되지 않아야 하는 경우
  "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/92.0.4515.115 Safari/537.36",
  "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/92.0.4515.115 Safari/537.36",
  "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/92.0.4515.115 Safari/537.36"
];

// 각 User Agent에 대해 함수 호출 및 결과 출력
testCases.forEach((userAgent, index) => {
  const isMobile = checkIfMobile(userAgent);
  console.log(`Test Case ${index + 1}: User Agent '${userAgent}' => Is Mobile Device? ${isMobile}`);
});
```